### PR TITLE
Fix crash when TriConfig.MEMORY_LEAK_FIX is null

### DIFF
--- a/src/main/java/com/falsepattern/triangulator/leakfix/LeakFix.java
+++ b/src/main/java/com/falsepattern/triangulator/leakfix/LeakFix.java
@@ -33,25 +33,30 @@ public final class LeakFix {
     private static long lastGC = 0;
 
     static {
-        switch (TriConfig.MEMORY_LEAK_FIX) {
-            default:
-                Triangulator.triLog.info("Disabling leak fix because of config flag.");
-                ENABLED = false;
-                break;
-            case Auto:
-                boolean isAMD = GL11.glGetString(GL11.GL_VENDOR).toLowerCase().contains("amd");
-                if (isAMD) {
-                    Triangulator.triLog.info("Enabling leak fix because an AMD gpu was detected.");
-                    ENABLED = true;
-                } else {
-                    Triangulator.triLog.info("Disabling leak fix because an AMD gpu was NOT detected.");
+        if(TriConfig.MEMORY_LEAK_FIX == null) {
+            Triangulator.triLog.info("Disabling leak fix because of uninitialized config.");
+            ENABLED = false;
+        } else {
+            switch (TriConfig.MEMORY_LEAK_FIX) {
+                default:
+                    Triangulator.triLog.info("Disabling leak fix because of config flag.");
                     ENABLED = false;
-                }
-                break;
-            case Enable:
-                Triangulator.triLog.info("Enabling leak fix because of config flag.");
-                ENABLED = true;
-                break;
+                    break;
+                case Auto:
+                    boolean isAMD = GL11.glGetString(GL11.GL_VENDOR).toLowerCase().contains("amd");
+                    if (isAMD) {
+                        Triangulator.triLog.info("Enabling leak fix because an AMD gpu was detected.");
+                        ENABLED = true;
+                    } else {
+                        Triangulator.triLog.info("Disabling leak fix because an AMD gpu was NOT detected.");
+                        ENABLED = false;
+                    }
+                    break;
+                case Enable:
+                    Triangulator.triLog.info("Enabling leak fix because of config flag.");
+                    ENABLED = true;
+                    break;
+            }
         }
     }
 


### PR DESCRIPTION
This can occur when FML encounters an error during modloading.