### PR TITLE
Add rudimentary compat with ArchaicFix's threaded chunk updating

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -13,4 +13,8 @@ dependencies {
     compileOnly("curse.maven:chromaticraft-235590:3574503") {
         transitive = false
     }
+
+    compileOnly("com.github.embeddedt:ArchaicFix:c6e3fc6") {
+        transitive = false
+    }
 }

--- a/src/main/java/com/falsepattern/triangulator/ToggleableTessellatorManager.java
+++ b/src/main/java/com/falsepattern/triangulator/ToggleableTessellatorManager.java
@@ -1,0 +1,28 @@
+package com.falsepattern.triangulator;
+
+import lombok.Getter;
+import lombok.experimental.Accessors;
+
+@Accessors(fluent = true,
+        chain = false)
+public class ToggleableTessellatorManager {
+    public static final ToggleableTessellatorManager INSTANCE = new ToggleableTessellatorManager();
+
+    @Getter
+    private int forceQuadRendering = 0;
+
+    public void disableTriangulator() {
+        forceQuadRendering++;
+    }
+
+    public void enableTriangulator() {
+        forceQuadRendering--;
+        if (forceQuadRendering < 0) {
+            forceQuadRendering = 0;
+        }
+    }
+
+    public boolean isTriangulatorDisabled() {
+        return !TriCompat.enableTriangulation() || forceQuadRendering == 0;
+    }
+}

--- a/src/main/java/com/falsepattern/triangulator/TriCompat.java
+++ b/src/main/java/com/falsepattern/triangulator/TriCompat.java
@@ -1,9 +1,40 @@
 package com.falsepattern.triangulator;
 
 import com.falsepattern.triangulator.config.TriConfig;
+import cpw.mods.fml.common.Loader;
+import lombok.Getter;
+import net.minecraft.client.renderer.Tessellator;
+import org.embeddedt.archaicfix.threadedupdates.api.ThreadedChunkUpdates;
 
 public class TriCompat {
+    public static void applyCompatibilityTweaks() {
+        if (Loader.isModLoaded("archaicfix")) {
+            ArchaicFixCompat.init();
+        }
+    }
+
     public static boolean enableTriangulation() {
         return TriConfig.ENABLE_QUAD_TRIANGULATION;
+    }
+
+    public static Tessellator tessellator() {
+        if(ArchaicFixCompat.isThreadedChunkUpdatingEnabled()) {
+            return ArchaicFixCompat.threadTessellator();
+        }
+        return Tessellator.instance;
+    }
+
+    private static class ArchaicFixCompat {
+
+        @Getter
+        private static boolean isThreadedChunkUpdatingEnabled;
+
+        private static void init() {
+            isThreadedChunkUpdatingEnabled = ThreadedChunkUpdates.isEnabled();
+        }
+
+        public static Tessellator threadTessellator() {
+            return ThreadedChunkUpdates.getThreadTessellator();
+        }
     }
 }

--- a/src/main/java/com/falsepattern/triangulator/api/ToggleableTessellator.java
+++ b/src/main/java/com/falsepattern/triangulator/api/ToggleableTessellator.java
@@ -20,12 +20,14 @@ public interface ToggleableTessellator {
 
     /**
      * Completely disables triangulation and falls back to quad rendering.
+     * Should not be called after mod loading has finished.
      */
     void disableTriangulator();
 
     /**
      * Disables the effect of {@link #disableTriangulator()}. If it was called multiple times, this method also needs to
      * be called at least the same amount of times to re-enable it.
+     * Should not be called after mod loading has finished.
      */
     void enableTriangulator();
 

--- a/src/main/java/com/falsepattern/triangulator/mixin/mixins/client/vanilla/RenderBlocksMixin.java
+++ b/src/main/java/com/falsepattern/triangulator/mixin/mixins/client/vanilla/RenderBlocksMixin.java
@@ -1,5 +1,6 @@
 package com.falsepattern.triangulator.mixin.mixins.client.vanilla;
 
+import com.falsepattern.triangulator.TriCompat;
 import com.falsepattern.triangulator.api.ToggleableTessellator;
 import com.falsepattern.triangulator.calibration.CalibrationConfig;
 import com.falsepattern.triangulator.mixin.helper.IRenderBlocksMixin;
@@ -20,7 +21,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
-import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 
@@ -113,7 +113,7 @@ public abstract class RenderBlocksMixin implements IRenderBlocksMixin {
         var avgBottomLeft = avg(colorRedBottomLeft, colorGreenBottomLeft, colorBlueBottomLeft);
         var avgBottomRight = avg(colorRedBottomRight, colorGreenBottomRight, colorBlueBottomRight);
         var avgTopRight = avg(colorRedTopRight, colorGreenTopRight, colorBlueTopRight);
-        if (((ToggleableTessellator) Tessellator.instance).isTriangulatorDisabled() &&
+        if (((ToggleableTessellator) TriCompat.tessellator()).isTriangulatorDisabled() &&
             CalibrationConfig.FLIP_DIAGONALS) {
             var tmp = avgTopLeft;
             avgTopLeft = avgBottomLeft;
@@ -128,21 +128,21 @@ public abstract class RenderBlocksMixin implements IRenderBlocksMixin {
             val mainDiagonalAvg = avg(avgTopLeft, avgBottomRight);
             val altDiagonalAvg = avg(avgBottomLeft, avgTopRight);
             if (Math.abs(mainDiagonalAvg - altDiagonalAvg) > 0.01 && mainDiagonalAvg < altDiagonalAvg) {
-                ((ITessellatorMixin) Tessellator.instance).alternativeTriangulation(true);
+                ((ITessellatorMixin) TriCompat.tessellator()).alternativeTriangulation(true);
                 return;
             }
         } else if (altDiagonalDiff < mainDiagonalDiff) {
-            ((ITessellatorMixin) Tessellator.instance).alternativeTriangulation(true);
+            ((ITessellatorMixin) TriCompat.tessellator()).alternativeTriangulation(true);
             return;
         }
-        ((ITessellatorMixin) Tessellator.instance).alternativeTriangulation(false);
+        ((ITessellatorMixin) TriCompat.tessellator()).alternativeTriangulation(false);
     }
 
     private void reuse(int index) {
         if (reusePreviousStates) {
-            ((ITessellatorMixin) Tessellator.instance).alternativeTriangulation(states[index]);
+            ((ITessellatorMixin) TriCompat.tessellator()).alternativeTriangulation(states[index]);
         } else {
-            states[index] = ((ITessellatorMixin) Tessellator.instance).alternativeTriangulation();
+            states[index] = ((ITessellatorMixin) TriCompat.tessellator()).alternativeTriangulation();
         }
     }
 

--- a/src/main/java/com/falsepattern/triangulator/mixin/mixins/client/vanilla/TessellatorMixin.java
+++ b/src/main/java/com/falsepattern/triangulator/mixin/mixins/client/vanilla/TessellatorMixin.java
@@ -1,5 +1,6 @@
 package com.falsepattern.triangulator.mixin.mixins.client.vanilla;
 
+import com.falsepattern.triangulator.ToggleableTessellatorManager;
 import com.falsepattern.triangulator.TriCompat;
 import com.falsepattern.triangulator.Triangulator;
 import com.falsepattern.triangulator.api.ToggleableTessellator;
@@ -45,7 +46,6 @@ public abstract class TessellatorMixin implements ITessellatorMixin, ToggleableT
     private boolean alternativeTriangulation = false;
     private boolean quadTriangulationTemporarilySuspended = false;
     private boolean shaderOn = false;
-    private int forceQuadRendering = 0;
     private int quadVerticesPutIntoBuffer = 0;
 
     @Inject(method = "reset",
@@ -65,7 +65,8 @@ public abstract class TessellatorMixin implements ITessellatorMixin, ToggleableT
                        target = "Lnet/minecraft/client/renderer/Tessellator;drawMode:I"),
               require = 1)
     private void forceDrawingTris(Tessellator instance, int value) {
-        if (TriCompat.enableTriangulation() && value == GL11.GL_QUADS && forceQuadRendering == 0) {
+        if (TriCompat.enableTriangulation() && value == GL11.GL_QUADS &&
+                ToggleableTessellatorManager.INSTANCE.forceQuadRendering() == 0) {
             hackedQuadRendering = true;
             value = GL11.GL_TRIANGLES;
         } else {
@@ -181,20 +182,17 @@ public abstract class TessellatorMixin implements ITessellatorMixin, ToggleableT
 
     @Override
     public void disableTriangulator() {
-        forceQuadRendering++;
+        ToggleableTessellatorManager.INSTANCE.disableTriangulator();
     }
 
     @Override
     public void enableTriangulator() {
-        forceQuadRendering--;
-        if (forceQuadRendering < 0) {
-            forceQuadRendering = 0;
-        }
+        ToggleableTessellatorManager.INSTANCE.enableTriangulator();
     }
 
     @Override
     public boolean isTriangulatorDisabled() {
-        return !TriCompat.enableTriangulation() || forceQuadRendering == 0;
+        return ToggleableTessellatorManager.INSTANCE.isTriangulatorDisabled();
     }
 
     @Override

--- a/src/main/java/com/falsepattern/triangulator/proxy/ClientProxy.java
+++ b/src/main/java/com/falsepattern/triangulator/proxy/ClientProxy.java
@@ -1,6 +1,7 @@
 package com.falsepattern.triangulator.proxy;
 
 import com.falsepattern.triangulator.ItemRenderListManager;
+import com.falsepattern.triangulator.TriCompat;
 import com.falsepattern.triangulator.calibration.Calibration;
 import com.falsepattern.triangulator.leakfix.LeakFix;
 
@@ -25,5 +26,6 @@ public class ClientProxy extends CommonProxy {
                 ItemRenderListManager.INSTANCE);
         LeakFix.gc();
         ClientCommandHandler.instance.registerCommand(new Calibration.CalibrationCommand());
+        TriCompat.applyCompatibilityTweaks();
     }
 }


### PR DESCRIPTION
ArchaicFix uses multiple tessellator instances, one for each worker thread, in order to perform most of the chunk updating work on parallel worker threads. This causes a problem with Triangulator, as it references `Tessellator.instance`, assuming only one tessellator instance is in use.

This PR makes Triangulator use ArchaicFix's API for getting the correct tessellator instance for the current thread. The implementation of `disableTriangulator` is changed to use a singleton object as `Tessellator.instance` is no longer a good place to store its data.

This fixes the visual glitches that happen when Triangulator is used together with ArchaicFix's threaded chunk updating.

However, this fix is not complete. The redstone paste mixin still references `Tessellator.instance`:

https://github.com/FalsePattern/Triangulator/blob/8d6f8fd6711dab592ee33e05680ffedac339f9f4/src/main/java/com/falsepattern/triangulator/mixin/mixins/client/redstonepaste/RedstonePasteHighlighterMixin.java#L15-L27

In order to finish the fix, Triangulator's API will have to be changed to allow suspending the thread-local tessellator instance exclusively. Maybe the `suspendQuadTriangulation` set of methods could be changed to allow suspending even before tessellation is started? It's either that, or creating a new set of methods, but that would seem like a mess.

---

~~I'll keep this as a draft until a version of AF with the API is released.~~ Actually I can just use jitpack.